### PR TITLE
Handle non-existent stacks

### DIFF
--- a/stack_termination_protection.py
+++ b/stack_termination_protection.py
@@ -41,6 +41,17 @@ class StackTerminationProtection(Hook):
             enable_termination_protection = True
         connection_manager = self.stack.connection_manager
         try:
+            connection_manager.call(
+                service="cloudformation",
+                command="describe_stacks",
+                kwargs={"StackName": self.stack.external_name}
+            )
+        except ClientError:
+            self.logger.info(
+                "%s - stack not found. Skipping termination protection",
+                self.stack.name)
+            return
+        try:
             response = connection_manager.call(
                 service="cloudformation",
                 command="update_termination_protection",


### PR DESCRIPTION
If Sceptre has a dependent stack, the stack may not exist when Sceptre
tries to delete it. This patch adds a check to ensure that the stack
exists prior to enabling or disabling the termination protection.